### PR TITLE
Feat/video tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Optional 3rd arg to pass a window.interval instance to be cleared once progress 
 ```Javascript
 import { permutiveVideoUtils } from "@phntms/ft-lib";
 
-const permutivevideoTracker = new permutiveVideoUtils("<FT CAMPAIGN>","<VIDEO-TITLE>","<VIDEO-ID/URL>")  //Data will be site implementation specific
+const permutivevideoTracker = new permutiveVideoUtils("<FT-CAMPAIGN>","<VIDEO-TITLE>","<VIDEO-ID/URL>")  //Data will be site implementation specific
 
 player.on("progress", () => {   //event will be video player site implementation specific
    permutivevideoTracker.emitPermutiveProgressEvent(<DURATION>, <CURRENTTIME>, <OPTIONAL-WINDOW-INTERVAL>)
@@ -52,10 +52,38 @@ player.on("progress", () => {   //event will be video player site implementation
 
 ### reactPlayerTracking
 
+Exports video event handlers that broadcast the required GA, oTracking and Permutive events.
+NOTE: Currently implemented for react-player implementations only but will be expanded to handle other video player implementations (Youtube Iframe API players specifically) which require slightly different 'progress' monitoring.
+
+The constructor takes the parent site's oTracking/Origami eventDispatcher function and video and site meta data (as required for the tracking data), along with an optional `options` object (see below)
+
+Typical implementation:
+
 ```Javascript
 import { reactPlayerTracking } from "@phntms/ft-lib";
 
-new consentMonitor("FT.staging.testsite.com". ["localhost", "phq", "staging"]);
+const [videoTracker] = useState(
+   new reactPlayerTracking(eventDispatcher, <VIDEO-TITLE>, <VIDEO-URL>,<FT-CAMPAIGN>,
+    { isPermutiveTracking: true },
+   ),
+)
+
+<ReactPlayer
+   onDuration={videoTracker.setDuration}
+   onEnded={videoTracker.trackEnded}
+   onPause={videoTracker.trackPause}
+   onPlay={videoTracker.trackPlay}
+   onProgress={videoTracker.trackProgress}
+>
+```
+
+### Default Options:
+
+```
+  isPermutiveTracking: false,
+  routeUrl: window.location.href,
+  category: "video",
+  product: "paid-post",
 ```
 
 [npm-image]: https://img.shields.io/npm/v/@phntms/ft-lib.svg?style=flat-square&logo=react

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ currently implemented:
 
 - consentMonitor - polls the FT consent cookies set by the approved FT Origami cookie banner to enable/disable the FT Permutive ad tracking
 - permutiveVideoUtils - formatted permutive video progress events
+- reactPlayerTracking - Consolidated video tracking (Google Analytics, FT Origami, Permutive) event handlers for FT sites implementing videos with [react-player](https://github.com/cookpete/react-player)
 
 ## Installation
 
@@ -23,7 +24,9 @@ npm i @phntms/ft-lib
 
 ## Usage
 
-consentMonitor - Adds an FT consent cookie poller to enable/disable Permutive consent (only useful if 'consentRequired' is set as an option in the site's Permutive script - see [here](https://support.permutive.com/hc/en-us/articles/360010845519-Seeking-User-Consent#h_00327830-509b-422a-952b-1906264031f1)
+### consentMonitor
+
+Adds an FT consent cookie poller to enable/disable Permutive consent (only useful if 'consentRequired' is set as an option in the site's Permutive script - see [here](https://support.permutive.com/hc/en-us/articles/360010845519-Seeking-User-Consent#h_00327830-509b-422a-952b-1906264031f1)
 There are optional constructor args for the hostname (defaults to window.location.hostname) and the dev environment host matches (defaults to ["localhost", "phq", "vercel.app"]) which are used to determine development environments in order to generate an FT banner event listener ((see [here](https://registry.origami.ft.com/components/o-cookie-message@6.0.1/readme?brand=master) for a list of banner DOM events) to set session-level cookies for development environments
 
 ```Javascript
@@ -32,7 +35,9 @@ import { consentMonitor } from "@phntms/ft-lib";
 new consentMonitor("FT.staging.testsite.com". ["localhost", "phq", "staging"]);
 ```
 
-permutiveVideoUtils - emitPermutiveProgressEvents - used within a video player's progress event handler to fire Permutive video progress events at [0, 25, 50, 75, 100] percent progress.
+### permutiveVideoUtils
+
+emitPermutiveProgressEvents - used within a video player's progress event handler to fire Permutive video progress events at [0, 25, 50, 75, 100] percent progress.
 Optional 3rd arg to pass a window.interval instance to be cleared once progress is complete.
 
 ```Javascript
@@ -43,6 +48,14 @@ const permutivevideoTracker = new permutiveVideoUtils("<FT CAMPAIGN>","<VIDEO-TI
 player.on("progress", () => {   //event will be video player site implementation specific
    permutivevideoTracker.emitPermutiveProgressEvent(<DURATION>, <CURRENTTIME>, <OPTIONAL-WINDOW-INTERVAL>)
 });
+```
+
+### reactPlayerTracking
+
+```Javascript
+import { reactPlayerTracking } from "@phntms/ft-lib";
+
+new consentMonitor("FT.staging.testsite.com". ["localhost", "phq", "staging"]);
 ```
 
 [npm-image]: https://img.shields.io/npm/v/@phntms/ft-lib.svg?style=flat-square&logo=react

--- a/package-lock.json
+++ b/package-lock.json
@@ -2857,6 +2857,12 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.12",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
@@ -3168,6 +3174,15 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "requires": {
+        "debug": "4"
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -4015,12 +4030,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
-    },
-    "decimal.js": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
       "dev": true
     },
     "decode-uri-component": {
@@ -5391,6 +5400,17 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -5400,6 +5420,16 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "human-signals": {
@@ -5494,12 +5524,6 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
-    },
-    "ip-regex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
-      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -5662,12 +5686,6 @@
       "requires": {
         "isobject": "^3.0.1"
       }
-    },
-    "is-potential-custom-element-name": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
-      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
-      "dev": true
     },
     "is-primitive": {
       "version": "3.0.1",
@@ -6242,9 +6260,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+          "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
           "dev": true
         },
         "acorn-globals": {
@@ -6255,6 +6273,14 @@
           "requires": {
             "acorn": "^7.1.1",
             "acorn-walk": "^7.1.1"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+              "dev": true
+            }
           }
         },
         "acorn-walk": {
@@ -6314,6 +6340,23 @@
             }
           }
         },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        },
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
         "html-encoding-sniffer": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -6324,43 +6367,71 @@
           }
         },
         "jsdom": {
-          "version": "16.4.0",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
-          "integrity": "sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==",
+          "version": "16.7.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
+          "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
           "dev": true,
           "requires": {
-            "abab": "^2.0.3",
-            "acorn": "^7.1.1",
+            "abab": "^2.0.5",
+            "acorn": "^8.2.4",
             "acorn-globals": "^6.0.0",
             "cssom": "^0.4.4",
-            "cssstyle": "^2.2.0",
+            "cssstyle": "^2.3.0",
             "data-urls": "^2.0.0",
-            "decimal.js": "^10.2.0",
+            "decimal.js": "^10.2.1",
             "domexception": "^2.0.1",
-            "escodegen": "^1.14.1",
+            "escodegen": "^2.0.0",
+            "form-data": "^3.0.0",
             "html-encoding-sniffer": "^2.0.1",
-            "is-potential-custom-element-name": "^1.0.0",
+            "http-proxy-agent": "^4.0.1",
+            "https-proxy-agent": "^5.0.0",
+            "is-potential-custom-element-name": "^1.0.1",
             "nwsapi": "^2.2.0",
-            "parse5": "5.1.1",
-            "request": "^2.88.2",
-            "request-promise-native": "^1.0.8",
-            "saxes": "^5.0.0",
+            "parse5": "6.0.1",
+            "saxes": "^5.0.1",
             "symbol-tree": "^3.2.4",
-            "tough-cookie": "^3.0.1",
+            "tough-cookie": "^4.0.0",
             "w3c-hr-time": "^1.0.2",
             "w3c-xmlserializer": "^2.0.0",
             "webidl-conversions": "^6.1.0",
             "whatwg-encoding": "^1.0.5",
             "whatwg-mimetype": "^2.3.0",
-            "whatwg-url": "^8.0.0",
-            "ws": "^7.2.3",
+            "whatwg-url": "^8.5.0",
+            "ws": "^7.4.6",
             "xml-name-validator": "^3.0.0"
+          },
+          "dependencies": {
+            "decimal.js": {
+              "version": "10.3.1",
+              "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+              "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
+              "dev": true
+            },
+            "escodegen": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+              "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+              "dev": true,
+              "requires": {
+                "esprima": "^4.0.1",
+                "estraverse": "^5.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
+              }
+            },
+            "is-potential-custom-element-name": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+              "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+              "dev": true
+            }
           }
         },
         "parse5": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
           "dev": true
         },
         "saxes": {
@@ -6372,21 +6443,28 @@
             "xmlchars": "^2.2.0"
           }
         },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        },
         "tough-cookie": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+          "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
           "dev": true,
           "requires": {
-            "ip-regex": "^2.1.0",
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
+            "psl": "^1.1.33",
+            "punycode": "^2.1.1",
+            "universalify": "^0.1.2"
           }
         },
         "tr46": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
-          "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+          "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
           "dev": true,
           "requires": {
             "punycode": "^2.1.1"
@@ -6408,20 +6486,20 @@
           "dev": true
         },
         "whatwg-url": {
-          "version": "8.4.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
-          "integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+          "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
           "dev": true,
           "requires": {
-            "lodash.sortby": "^4.7.0",
-            "tr46": "^2.0.2",
+            "lodash": "^4.7.0",
+            "tr46": "^2.1.0",
             "webidl-conversions": "^6.1.0"
           }
         },
         "ws": {
-          "version": "7.5.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.2.tgz",
-          "integrity": "sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ==",
+          "version": "7.5.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+          "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
           "dev": true
         }
       }
@@ -7399,9 +7477,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -7432,14 +7510,14 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -9857,6 +9935,12 @@
           }
         }
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@phntms/ft-lib",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@phntms/ft-lib",
   "description": "A collection of Javascript UI & tracking utils for FT sites",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "homepage": "https://github.com/phantomstudios/ft-lib#readme",

--- a/src/consentMonitor/index.ts
+++ b/src/consentMonitor/index.ts
@@ -1,7 +1,7 @@
 import Debug from "debug";
 const debug = Debug("@phntms/ft-lib");
 
-const DEFAULT_DEV_HOSTS = ["localhost", "phq", "vercel.app"];
+const DEFAULT_DEV_HOSTS = ["localhost", "phq", ".app", "preview"];
 
 export class consentMonitor {
   protected _consent = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { consentMonitor } from "./consentMonitor";
 export { permutiveVideoUtils } from "./permutiveVideoUtils";
+export { reactPlayerTracking } from "./reactPlayerTracking";

--- a/src/reactPlayerTracking/index.ts
+++ b/src/reactPlayerTracking/index.ts
@@ -1,0 +1,147 @@
+/** FT tracking video event handlers for React-Player event handler props (onEnded, onPause, onPlay, onProgress) */
+import Debug from "debug";
+
+import { permutiveVideoUtils } from "../permutiveVideoUtils";
+const debug = Debug("@phntms/ft-lib");
+
+interface Options {
+  isOTracking?: boolean;
+  isGATracking?: boolean;
+  isPermutiveTracking?: boolean;
+  routeUrl?: string;
+  /** video/article/stream  */
+  category?: string;
+  /** paid-post */
+  product?: string;
+}
+
+const DEFAULT_OPTIONS = {
+  isOTracking: true,
+  isGATracking: true,
+  isPermutiveTracking: false,
+  routeUrl: typeof window !== "undefined" ? window.location.href : undefined,
+  category: "Video",
+  product: "paid-post",
+};
+
+interface PlayerProgressEvent {
+  played: number;
+  loaded: number;
+  playedSeconds: number;
+  loadedSeconds: number;
+}
+
+export class reactPlayerTracking {
+  duration = 0;
+  playedSeconds = 0;
+  playedPercent = 0;
+  oTrackingEvent: any;
+  gaTrackingEvent: any;
+  videoTitle: string;
+  videoUrl: string;
+  campaign: string;
+  options: Options;
+  /** 100% is fired with ended event */
+  GA_milestones: number[] = [1, 25, 50];
+  oTracking_milestones: number[] = [25, 50, 75];
+  permutiveTracker: permutiveVideoUtils | undefined;
+
+  constructor(
+    /** oTracking dispatch event function */
+    oTrackingEvent: any,
+    /** gaTracking dispatch event function */
+    gaTrackingEvent: any,
+    /** video page title */
+    videoTitle: string,
+    /** video/youtube url or youtube ID */
+    videoUrl: string,
+    /** From brand tracking template, e.g.  Shaping Digital Future */
+    campaign: string,
+    /** optional config */
+    options?: Options
+  ) {
+    this.oTrackingEvent = oTrackingEvent;
+    this.gaTrackingEvent = gaTrackingEvent;
+    this.videoTitle = videoTitle;
+    this.videoUrl = videoUrl;
+    this.campaign = campaign;
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+    if (this.options.isPermutiveTracking) {
+      this.permutiveTracker = new permutiveVideoUtils(
+        campaign,
+        videoTitle,
+        videoUrl
+      );
+    }
+  }
+
+  setDuration = (duration: number) => {
+    this.duration = Math.floor(duration);
+  };
+
+  sendGAEvent = (action: string) => {
+    this.gaTrackingEvent({
+      action: action,
+      category: this.options.category,
+      label: this.videoTitle,
+    });
+  };
+
+  sendoTrackingEvent = (action: string, progress?: number) => {
+    this.oTrackingEvent({
+      category: this.options.category,
+      action: action,
+      product: this.options.product,
+      app: this.options.category,
+      duration: this.duration,
+      progress: progress ? `${progress}%` : `${this.playedPercent}%`,
+      url: this.options.routeUrl,
+    });
+  };
+
+  trackPlay = () => {
+    this.sendGAEvent("playing");
+    this.sendoTrackingEvent("playing");
+  };
+
+  trackPause = () => {
+    this.sendGAEvent("pause");
+    this.sendoTrackingEvent("pause");
+  };
+
+  trackEnded = () => {
+    //fire 100% progress events
+    this.sendGAEvent("100% watched");
+    this.sendoTrackingEvent("progress", 100);
+
+    this.sendGAEvent("ended");
+    this.sendoTrackingEvent("ended", 100);
+  };
+
+  trackProgress = (reactPlayerProgress: PlayerProgressEvent) => {
+    this.playedSeconds = reactPlayerProgress.playedSeconds;
+    if (this.duration > 0) {
+      this.playedPercent = Math.floor(
+        (Math.ceil(reactPlayerProgress.playedSeconds) / this.duration) * 100
+      );
+    }
+
+    while (this.playedPercent >= this.GA_milestones[0]) {
+      this.sendGAEvent(`${this.GA_milestones[0]}% watched`);
+      this.GA_milestones.shift();
+    }
+
+    while (this.playedPercent >= this.oTracking_milestones[0]) {
+      this.sendoTrackingEvent("progress", this.oTracking_milestones[0]);
+      this.oTracking_milestones.shift();
+    }
+
+    //permutive only tracks progress events and contains its own milestones
+    if (this.options.isPermutiveTracking) {
+      this.permutiveTracker?.emitPermutiveProgressEvent(
+        this.duration,
+        this.playedSeconds
+      );
+    }
+  };
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,5 @@
 interface Window {
+  dataLayer: any;
   permutive: {
     addon: any;
     consent: CallableConsent;
@@ -13,4 +14,14 @@ interface ConsentOptions {
 
 interface CallableConsent {
   ({}: ConsentOptions): void;
+}
+
+interface VideoTrackingOptions {
+  isOTracking?: boolean;
+  isGATracking?: boolean;
+  isPermutiveTracking?: boolean;
+  GA_datalayer?: any;
+  GA_milestones?: number[];
+  oTracking_milestones?: number[];
+  route_url?: string;
 }

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -18,7 +18,7 @@ describe("consentMonitor", () => {
   });
   it("sets default dev hosts property", async () => {
     const obj = new consentMonitor("https://FT-staging.com");
-    expect(obj.devHosts).toEqual(["localhost", "phq", "vercel.app"]);
+    expect(obj.devHosts).toEqual(["localhost", "phq", ".app", "preview"]);
   });
   it("matches hostname to devHosts", async () => {
     const obj = new consentMonitor("https://FT-staging.devhost.com", [


### PR DESCRIPTION
Adds reactPlayerTracking class for consolidated FT tracking for react-player implementations.

- main aim is a halfway house to resolve incorrect video tracking formats without uplifting the full data tracking layer from each site.
- constructor therefore requires the oTracking 'eventDispatcher' function to be passed in for the Origami events, window.dataLayer can be generically used for GA event.
- Permutive video tracking was already implemented in this lib and is re-used
- Tested on Teamviewer and Equinor which have corresponding PRs.

Next steps:
- implement in FT-galaxy
- Add 'youtubeIframeApiPlayer' equivalent for Wagtail video implementations (i.e. Channels) and move shared event broadcast functionality to a separate file/class.
- Move more of the tracking layer (origami utils, scroll tracking etc. to this library)
- A new `ft-react-llb' library that implements HOC components for reuseable video-players, headers, footers etc. can use this lower level lib.