### PR TITLE
Add specific TCF API lookup to return Brandmetrics and Linkedin cookie banner consents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@phantomstudios/ft-lib",
-  "version": "0.5.2-rc2",
+  "version": "0.5.2-rc5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@phantomstudios/ft-lib",
-      "version": "0.5.2-rc2",
+      "version": "0.5.2-rc5",
       "license": "MIT",
       "dependencies": {
         "yup": "^1.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@phantomstudios/ft-lib",
-  "version": "0.5.2-rc5",
+  "version": "0.5.2-rc6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@phantomstudios/ft-lib",
-      "version": "0.5.2-rc5",
+      "version": "0.5.2-rc6",
       "license": "MIT",
       "dependencies": {
         "yup": "^1.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@phantomstudios/ft-lib",
-  "version": "0.5.1",
+  "version": "0.5.2-rc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@phantomstudios/ft-lib",
-      "version": "0.5.1",
+      "version": "0.5.2-rc2",
       "license": "MIT",
       "dependencies": {
         "yup": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@phantomstudios/ft-lib",
   "description": "A collection of Javascript UI & tracking utils for FT sites",
-  "version": "0.5.2-rc5",
+  "version": "0.5.2-rc6",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "homepage": "https://github.com/phantomstudios/ft-lib#readme",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@phantomstudios/ft-lib",
   "description": "A collection of Javascript UI & tracking utils for FT sites",
-  "version": "0.5.2-rc2",
+  "version": "0.5.2-rc5",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "homepage": "https://github.com/phantomstudios/ft-lib#readme",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@phantomstudios/ft-lib",
   "description": "A collection of Javascript UI & tracking utils for FT sites",
-  "version": "0.5.1",
+  "version": "0.5.2-rc2",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "homepage": "https://github.com/phantomstudios/ft-lib#readme",

--- a/src/cmp/loadFtCmp.ts
+++ b/src/cmp/loadFtCmp.ts
@@ -20,9 +20,12 @@ export function loadFtCmpScript(): Promise<void> {
   });
 }
 
-export function enqueueCmpCallback(cb: () => void): void {
-  if (!window._sp_) window._sp_ = {};
-  if (!window._sp_queue) window._sp_queue = [];
+export function initCmpQueue(): void {
+  window._sp_ = window._sp_ || {};
+  window._sp_queue = window._sp_queue || [];
+}
 
+export function enqueueCmpCallback(cb: () => void): void {
+  initCmpQueue();
   window._sp_queue!.push(cb);
 }

--- a/src/cmp/vendorConsent.ts
+++ b/src/cmp/vendorConsent.ts
@@ -19,12 +19,14 @@ interface TCFData {
   vendor?: {
     consents?: Record<number, boolean>;
   };
+  gdprApplies?: boolean | undefined;
 }
 
 export interface VendorConsentResults {
   brandmetrics: boolean;
   linkedIn: boolean;
   purpose1: boolean;
+  gdprApplies: boolean;
 }
 
 export function initVendorConsentListener(
@@ -53,10 +55,13 @@ export function initVendorConsentListener(
       // Purpose 1: Device storage/access (Cookies)
       const purpose1 = tcData.purpose?.consents?.[1] === true;
 
+      const gdprApplies = tcData.gdprApplies !== false ? true : false;
+
       const results: VendorConsentResults = {
         brandmetrics,
         linkedIn,
         purpose1,
+        gdprApplies,
       };
 
       // Trigger your callback handler with the updated states

--- a/src/cmp/vendorConsent.ts
+++ b/src/cmp/vendorConsent.ts
@@ -1,0 +1,77 @@
+// 1. Declare Global Window Types for TCF API
+declare global {
+  interface Window {
+    __tcfapi?: (
+      command: string,
+      version: number,
+      callback: (tcData: TCFData | null, success: boolean) => void,
+      parameter?: any,
+    ) => void;
+  }
+}
+
+interface TCFData {
+  eventStatus: "tcloaded" | "useractioncomplete" | "cmpuishown";
+  listenerId: number;
+  purpose?: {
+    consents?: Record<number, boolean>;
+  };
+  vendor?: {
+    consents?: Record<number, boolean>;
+  };
+}
+
+export interface VendorConsentResults {
+  brandmetrics: boolean;
+  linkedIn: boolean;
+  purpose1: boolean;
+}
+
+// 2. Main Implementation Function
+export function initVendorConsentListener(
+  onConsentUpdate: (results: VendorConsentResults) => void,
+): void {
+  if (typeof window.__tcfapi !== "function") {
+    console.warn("[CMP] window.__tcfapi is not defined on this page yet.");
+    return;
+  }
+
+  window.__tcfapi("addEventListener", 2, (tcData, success) => {
+    if (!success || !tcData) return;
+
+    // Handles BOTH returning visitors ('tcloaded') AND live banner accepts ('useractioncomplete')
+    const isConsentReady =
+      tcData.eventStatus === "tcloaded" ||
+      tcData.eventStatus === "useractioncomplete";
+
+    if (isConsentReady) {
+      // Brandmetrics (IAB Vendor ID: 422)
+      const brandmetrics = tcData.vendor?.consents?.[422] === true;
+
+      // LinkedIn (IAB Vendor ID: 804)
+      const linkedIn = tcData.vendor?.consents?.[804] === true;
+
+      // Purpose 1: Device storage/access (Cookies)
+      const purpose1 = tcData.purpose?.consents?.[1] === true;
+
+      const results: VendorConsentResults = {
+        brandmetrics,
+        linkedIn,
+        purpose1,
+      };
+
+      // Trigger your callback handler with the updated states
+      onConsentUpdate(results);
+
+      // Clean up listener after handling the event
+      if (typeof tcData.listenerId === "number") {
+        window.__tcfapi?.(
+          "removeEventListener",
+          2,
+          () => {},
+          tcData.listenerId,
+        );
+      }
+    }
+  });
+}

--- a/src/cmp/vendorConsent.ts
+++ b/src/cmp/vendorConsent.ts
@@ -27,7 +27,6 @@ export interface VendorConsentResults {
   purpose1: boolean;
 }
 
-// 2. Main Implementation Function
 export function initVendorConsentListener(
   onConsentUpdate: (results: VendorConsentResults) => void,
 ): void {

--- a/src/consentMonitor/index.ts
+++ b/src/consentMonitor/index.ts
@@ -104,13 +104,15 @@ export class ConsentMonitor {
 
   // Added for required brandmetrics image pixels and linkedin script consent (CMP specific vendor consents integration)
   private attachVendorConsentListeners(): void {
-    initVendorConsentListener((vendorConsents: VendorConsentResults) => {
-      const vendorConsentEvent = new CustomEvent("cmp_vendorConsent", {
-        detail: vendorConsents,
-      });
+    enqueueCmpCallback(() => {
+      initVendorConsentListener((vendorConsents: VendorConsentResults) => {
+        const vendorConsentEvent = new CustomEvent("cmp_vendorConsent", {
+          detail: vendorConsents,
+        });
 
-      window.dispatchEvent(vendorConsentEvent);
-      debug("[CMP Consent lookup Event", vendorConsents);
+        window.dispatchEvent(vendorConsentEvent);
+        debug("[CMP Consent lookup Event", vendorConsents);
+      });
     });
   }
 
@@ -123,6 +125,15 @@ export class ConsentMonitor {
         } else {
           this.disablePermutive();
         }
+
+        initVendorConsentListener((vendorConsents: VendorConsentResults) => {
+          const vendorConsentEvent = new CustomEvent("cmp_vendorConsent", {
+            detail: vendorConsents,
+          });
+
+          window.dispatchEvent(vendorConsentEvent);
+          debug("[CMP Consent lookup Event", vendorConsents);
+        });
       };
 
       const onChoice: MessageChoiceHandler = (_l, _c, typeId) => {

--- a/src/consentMonitor/index.ts
+++ b/src/consentMonitor/index.ts
@@ -6,6 +6,10 @@ import {
 import Debug from "debug";
 
 import { enqueueCmpCallback, loadFtCmpScript } from "../cmp/loadFtCmp";
+import {
+  initVendorConsentListener,
+  VendorConsentResults,
+} from "../cmp/vendorConsent";
 
 const debug = Debug("@phantomstudios/ft-lib/consentMonitor");
 
@@ -35,6 +39,11 @@ export class ConsentMonitor {
   private _isDevEnvironment = false;
   private _isInitialized = false;
   private _hostname: string;
+  private _vendorConsents = {
+    brandmetrics: false,
+    linkedIn: false,
+    purpose1: false,
+  } as VendorConsentResults;
 
   public get consent(): boolean {
     return this._consent;
@@ -48,9 +57,11 @@ export class ConsentMonitor {
   public get isInitialized(): boolean {
     return this._isInitialized;
   }
-
   public get userHasConsented(): boolean {
     return this._consent;
+  }
+  public get vendorConsents(): VendorConsentResults {
+    return this._vendorConsents;
   }
 
   getCookieValue = (name: string) =>
@@ -71,10 +82,12 @@ export class ConsentMonitor {
       this._hostname.includes(h),
     );
 
+    this.attachVendorConsentListeners(); // listen to existing consent data fetch
+    this.attachCmpListeners(); // listen to banner interaction
+
+    // load banner
     loadFtCmpScript()
       .then(() => {
-        this.attachCmpListeners();
-
         const propertyConfig = window.location.hostname.endsWith(".ft.com")
           ? properties["FT_DOTCOM_PROD"]
           : properties["FT_DOTCOM_TEST"];
@@ -87,6 +100,18 @@ export class ConsentMonitor {
         this._isInitialized = true;
       })
       .catch((err) => console.error(err));
+  }
+
+  // Added for required brandmetrics image pixels and linkedin script consent (CMP specific vendor consents integration)
+  private attachVendorConsentListeners(): void {
+    initVendorConsentListener((vendorConsents: VendorConsentResults) => {
+      const vendorConsentEvent = new CustomEvent("cmp_vendorConsent", {
+        detail: vendorConsents,
+      });
+
+      window.dispatchEvent(vendorConsentEvent);
+      debug("[CMP Consent lookup Event", vendorConsents);
+    });
   }
 
   private attachCmpListeners(): void {


### PR DESCRIPTION
- send returned consent (fires on both fresh and returning sessions)
